### PR TITLE
Fix importprivkey statement to not rescan.

### DIFF
--- a/import.py
+++ b/import.py
@@ -46,6 +46,6 @@ confidential_address = wally.confidential_addr_from_addr(
     unconfidential_address, CA_PREFIX, blinding_public_key)
 
 print('liquid-cli importaddress {}'.format(unconfidential_address))
-print('liquid-cli importprivkey {} false'.format(private_key_wif))
+print('liquid-cli importprivkey {} "" false'.format(private_key_wif))
 print('liquid-cli importblindingkey {} {}'.format(confidential_address,
                                                   b2h(blinding_private_key)))


### PR DESCRIPTION
This adds an empty string for the label argument and moves 'false' to the correct position to prevent a rescan when importing the private key.

Arguments:
1. "bitcoinprivkey"   (string, required) The private key (see dumpprivkey)
2. "label"            (string, optional, default="") An optional label
3. rescan               (boolean, optional, default=true) Rescan the wallet for transactions
